### PR TITLE
レビュー②

### DIFF
--- a/src/app/api/world-posts/[id]/route.ts
+++ b/src/app/api/world-posts/[id]/route.ts
@@ -2,28 +2,29 @@
 // PUT→〜/api/worldPosts/[id]：特定の投稿を更新する
 // DELETE→〜/api/worldPosts/[id]：特定の投稿を削除する
 
-import prisma from "@/app/lib/prismaClient";
-import { NextResponse } from "next/server";
+import prisma from '@/app/lib/prismaClient';
+import { NextResponse } from 'next/server';
 
 interface Params {
   id: string;
-  countryName: string;
+  // countryName: string;
 }
 
 // 特定の投稿データの取得
 export async function GET(request: Request, { params }: { params: Params }) {
   const id = parseInt(params.id);
-  const { countryName } = params;
+  // const { countryName } = params;
 
   const worldPostData = await prisma.post.findFirst({
-    where: { id, countryName },
+    // where: { id, countryName },
+    where: { id },
   });
 
   if (!worldPostData) {
     return NextResponse.json(
       {
         success: false,
-        message: "投稿データ取得に失敗しました",
+        message: '投稿データ取得に失敗しました',
         data: null,
       },
       {
@@ -34,7 +35,7 @@ export async function GET(request: Request, { params }: { params: Params }) {
   return NextResponse.json(
     {
       success: true,
-      message: "投稿データ取得に成功しました",
+      message: '投稿データ取得に成功しました',
       data: worldPostData,
     },
     {
@@ -46,14 +47,14 @@ export async function GET(request: Request, { params }: { params: Params }) {
 // 特定の投稿データの更新
 export async function PATCH(request: Request, { params }: { params: Params }) {
   const id = parseInt(params.id);
-  const { countryName } = params;
+  // const { countryName } = params;
 
   const { title, content, createdAt } = await request.json();
 
   const newWorldPostData = await prisma.post.update({
     where: {
       id,
-      countryName,
+      // countryName,
     },
     data: {
       title,
@@ -64,7 +65,7 @@ export async function PATCH(request: Request, { params }: { params: Params }) {
   return NextResponse.json(
     {
       success: true,
-      message: "投稿更新",
+      message: '投稿更新',
       data: newWorldPostData,
     },
     {
@@ -85,7 +86,7 @@ export async function DELETE(request: Request, { params }: { params: Params }) {
   return NextResponse.json(
     {
       success: true,
-      message: "投稿削除",
+      message: '投稿削除',
       data: null,
     },
     {

--- a/src/app/api/world-posts/route.ts
+++ b/src/app/api/world-posts/route.ts
@@ -10,7 +10,6 @@ export async function GET(request: NextRequest) {
   const encodedCountryName = searchParams.get("country-name");
   if (!encodedCountryName) return NextResponse.json({ success: false, message: "国名が指定されていません" }, { status: 400 });
   const decodedCountryName = decodeURIComponent(encodedCountryName);
-  console.log("countryName", decodedCountryName);
   const worldPostData = await prisma.post.findMany({
     where: {
       countryName: decodedCountryName,

--- a/src/app/api/world-posts/route.ts
+++ b/src/app/api/world-posts/route.ts
@@ -1,12 +1,21 @@
 // GET→〜/api/world-posts：投稿の一覧を取得する
 // POST→〜/api/world-posts：投稿を新規作成する
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/app/lib/prismaClient";
 
 // 全投稿データを取得
-export async function GET() {
-  const worldPostData = await prisma.post.findMany();
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const encodedCountryName = searchParams.get("country-name");
+  if (!encodedCountryName) return NextResponse.json({ success: false, message: "国名が指定されていません" }, { status: 400 });
+  const decodedCountryName = decodeURIComponent(encodedCountryName);
+  console.log("countryName", decodedCountryName);
+  const worldPostData = await prisma.post.findMany({
+    where: {
+      countryName: decodedCountryName,
+    },
+  });
   // 取得した投稿データを返す
   return NextResponse.json(
     {

--- a/src/app/api/world-posts/route.ts
+++ b/src/app/api/world-posts/route.ts
@@ -6,9 +6,15 @@ import prisma from "@/app/lib/prismaClient";
 
 // 全投稿データを取得
 export async function GET(request: NextRequest) {
+  // クエリパラメータから国名を取得
   const searchParams = request.nextUrl.searchParams;
+  // TIPS: クエリパラメータはURIエンコードされているため、デコードして取得する必要がある
+  // TIPS：URIエンコードとはセキュリティなどの理由でURIに使用できない文字を変換すること
+  // TIPS：デコードとはURIエンコードされた文字列を元に戻すこと
   const encodedCountryName = searchParams.get("country-name");
+  // 国名が指定されていない場合はエラーを返す
   if (!encodedCountryName) return NextResponse.json({ success: false, message: "国名が指定されていません" }, { status: 400 });
+  // デコードした国名を取得
   const decodedCountryName = decodeURIComponent(encodedCountryName);
   const worldPostData = await prisma.post.findMany({
     where: {

--- a/src/components/WorldMapPage.tsx
+++ b/src/components/WorldMapPage.tsx
@@ -8,12 +8,13 @@ import {
   LoadScript,
   InfoWindow,
   Marker,
+  useLoadScript,
 } from "@react-google-maps/api";
 import { useRef, useState } from "react";
 import PostLists from "./PostLists";
 
 // google map api
-const googleMapsApiKey = process.env.NEXT_PUBLIC_MAPS_API_KEY;
+const googleMapsApiKey = process.env.NEXT_PUBLIC_MAPS_API_KEY!;
 
 // オプションのデフォルト値
 const DEFAULT_OPTIONS = {
@@ -25,6 +26,11 @@ const DEFAULT_OPTIONS = {
 };
 
 const WorldMapPage = () => {
+  const { isLoaded } = useLoadScript({
+    id: 'google-map-script',
+    googleMapsApiKey,
+    libraries: ['geometry', 'drawing'],
+  })
   // 国を選択するuseState
   const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
   // ↓各国の緯度経度の初期値
@@ -112,7 +118,7 @@ const WorldMapPage = () => {
     setZoomPostList(!zoomPostList);
   };
 
-  if (!googleMapsApiKey) {
+  if (!isLoaded) {
     return <Box>Google Maps API キーが見つかりません。</Box>;
   }
 
@@ -120,8 +126,8 @@ const WorldMapPage = () => {
     <>
       <Box>
         {zoomPostList && <PostLists country={countryName} />}
-        <LoadScript googleMapsApiKey={googleMapsApiKey}>
-          <GoogleMap
+        {/* <LoadScript googleMapsApiKey={googleMapsApiKey}> */}
+          {isLoaded && <GoogleMap
             mapContainerStyle={mapContainerStyle}
             center={mapCenter}
             zoom={zoom}
@@ -168,8 +174,8 @@ const WorldMapPage = () => {
                 </InfoWindow>
               ) : null
             )}
-          </GoogleMap>
-        </LoadScript>
+          </GoogleMap>}
+        {/* </LoadScript> */}
       </Box>
       <Button position="fixed" bottom="5">
         ログアウト


### PR DESCRIPTION
## やりたいこと
- 国ごとの投稿情報を作成するためにAPIを修正する
- 国ごとの投稿情報の一覧を取得するためにAPIを修正する

## 変更内容
### 1. /world-posts/[id]系のAPIの修正
src/app/api/world-posts/[id]/route.tsに実装された各APIは今回のやりたいことには関係ないので、修正不要です！
理由としては、各投稿情報はIDのみあれば操作可能であるからです。

### 2. /world-postsのGETの修正
src/app/api/world-posts/route.tsにあるGETリクエストが今回の修正の対象となります。
具体的には以下の変更を行いました。

1. URLのクエリパラメータのうちkeyが`country-name`である組み合わせの値を取得する
2. URLのクエリパラメータはURIエンコードされるため、デコードして元の文字に戻す
     1. URIエンコードの解説は以下を参考にしてみてください
         1. https://wa3.i-3-i.info/word135.html
3. デコードされた文字（国名）をprismaによるデータベース操作のwhere条件に指定して実行する

