### PR TITLE
Userモデルのemailが一意となるように制約を追加、NextAuthのauthorizeメソッドのuserのidを文字列変換するように修正

### DIFF
--- a/prisma/migrations/20241108042154_20241108_change_user_email_to_unique/migration.sql
+++ b/prisma/migrations/20241108042154_20241108_change_user_email_to_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[email]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,7 @@ model Post {
 
 model User {
   id Int @id @default(autoincrement())
-  email String
+  email String @unique
   password String
   name String?
   image String

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -32,7 +32,7 @@ const handler = NextAuth({
           (await bcrypt.compare(credentials!.password, user.password))
         ) {
           return {
-            id: user.id,
+            id: user.id.toString(),
             email: user.email,
             name: user.name,
             password: user.password,


### PR DESCRIPTION
## 変更内容

- Userモデルのemailが一意となるように制約を追加
    - prismaのfindUniqueメソッドはユーザーを一意に識別できるwhere句の条件が必要ですが、emailは重複して登録されても問題ないようになっていました
    - そのため、 emailが重複登録できないように、Userモデルのemailカラムに@uniqueを追加しました
        - https://www.prisma.io/docs/orm/reference/prisma-schema-reference#unique-1
- NextAuthのauthorizeメソッドのuserのidを文字列変換するように修正
    - NextAuthにユーザー情報を登録するには、idプロパティの値は文字列である必要がありますが、Userモデルではidが数値になっていたので警告されていた状況でした 