### PR TITLE
ユーザーのアイコンURLの取得とアイコン表示

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,11 +1,11 @@
-import NextAuth from "next-auth";
+import NextAuth, { NextAuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
 import prisma from "@/app/lib/prismaClient";
 import bcrypt from "bcrypt";
 import { Prisma } from "@prisma/client";
 
-const handler = NextAuth({
+export const handler: NextAuthOptions = NextAuth({
   providers: [
     // ↓Googleログイン
     GoogleProvider({

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,0 +1,62 @@
+import prisma from '@/app/lib/prismaClient';
+import { getServerSession, Session } from 'next-auth';
+import { handler } from '../auth/[...nextauth]/route';
+
+// ユーザー情報取得API
+export async function GET() {
+  // セッション情報を取得
+  let session: Session | null;
+  try {
+    session = await getServerSession(handler);
+
+    // 取得できたセッション情報が空の場合は401エラーを返す
+    if (!session) {
+      return Response.json(
+        {
+          message: 'ログインしていません',
+        },
+        {
+          status: 401,
+        }
+      );
+    }
+  } catch (error) {
+    // セッション情報の取得に失敗した場合は500エラーを返す
+    return Response.json(
+      {
+        message: 'セッション情報の取得に失敗しました',
+      },
+      {
+        status: 500,
+      }
+    );
+  }
+
+  // セッション情報からユーザー情報を取得して返す
+  try {
+    // セッション情報からユーザー情報を取得
+    const res = await prisma.user.findUnique({
+      where: {
+        email: session.user.email,
+      },
+    });
+    return Response.json(
+      {
+        data: res,
+      },
+      {
+        status: 200,
+      }
+    );
+  } catch (error) {
+    // ユーザー情報の取得に失敗した場合は500エラーを返す
+    return Response.json(
+      {
+        message: 'ユーザー情報の取得に失敗しました',
+      },
+      {
+        status: 500,
+      }
+    );
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,14 @@
+import prisma from "@/app/lib/prismaClient";
 import { Avatar, Box, Heading } from "@chakra-ui/react";
-import { createClient } from "@supabase/supabase-js";
+import { User } from "@prisma/client";
+// import { createClient } from "@supabase/supabase-js";
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+// const supabase = createClient(
+//   process.env.NEXT_PUBLIC_SUPABASE_URL!,
+//   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+// );
 
 const Header = () => {
   const { data: session } = useSession();
@@ -17,17 +19,27 @@ const Header = () => {
 
     const fetchAvatarUrl = async () => {
       if (session?.user?.email) {
-        const { data } = supabase.storage
-          .from("user-image-buket")
-          .getPublicUrl(`public/${session?.user?.email}`);
+        // const { data } = supabase.storage
+        //   .from("user-image-buket")
+        //   .getPublicUrl(`public/${session?.user?.email}`);
 
-        if (!data?.publicUrl) {
+        const response = await fetch(`http://localhost:3000/api/user`);
+        const { data }: { data: User } = await response.json();
+
+        if (!data.image) {
           console.error("画像URL取得に失敗");
           setAvatarUrl("/default-avatar.jpeg");
         } else {
-          console.log("画像URL", data.publicUrl);
-          setAvatarUrl(data.publicUrl);
+          console.log("画像URL", data.image);
+          setAvatarUrl(data.image);
         }
+        // if (!data?.publicUrl) {
+        //   console.error("画像URL取得に失敗");
+        //   setAvatarUrl("/default-avatar.jpeg");
+        // } else {
+        //   console.log("画像URL", data.publicUrl);
+        //   setAvatarUrl(data.publicUrl);
+        // }
       }
     };
     fetchAvatarUrl();


### PR DESCRIPTION
## 変更内容

- NextAuthで保存されているセッション情報をRoute Handlerから取得できるように変更
- ユーザー情報を取得するための`/api/user`のエンドポイントを作成
- src/components/Header.tsxにて、`/api/user`からユーザー情報を取得してアイコン表示を行う処理を追加

## ユーザーのアイコンを表示するまでの流れ
1. ログインする
2. /worldに遷移する
3. セッション情報を取得する
4. セッション情報のメールアドレスを元に、`/api/user`からユーザー情報を取得する
5. 取得したユーザー情報からアイコンURL（imageカラム）を抽出する
6. 取得したアイコンURLを元にアイコンを表示する